### PR TITLE
feat(#6): add support for writing docs to other dbs

### DIFF
--- a/src/design-context.ts
+++ b/src/design-context.ts
@@ -1,14 +1,6 @@
 import { DesignContext } from './doc-design.js';
+import { environment } from './environment.js';
 
-const getUsername = () => {
-  const parseUserNameFromURL = /https?:\/\/(.*):.*@.*/;
-  const couchURL = process.env.COUCH_URL;
-  const match = parseUserNameFromURL.exec(couchURL);
-  if (!match) {
-    console.error('Failed to parse username from COUCH_URL.');
-    return null;
-  }
-  return match[1];
+export const context = {
+  get: (): DesignContext => ({ username: environment.getUsername() })
 };
-
-export const getContext = (): DesignContext => ({ username: getUsername() });

--- a/src/doc-design.ts
+++ b/src/doc-design.ts
@@ -20,13 +20,18 @@ export type DocDesign = (context: DesignContext) => DesignSpec[];
  */
 export interface DesignSpec {
   /**
-   * The number of documents of this type to generate. This also servers as the batch size of docs to upload.
+   * Required. The number of documents of this type to generate. This also servers as the batch size of docs to upload.
    */
   amount: number;
 
   /**
-   * Returns the document to generate. If no `_id` value is provided, one will be generated automatically. This
-   * function is call the number of times defined in the `amount` property.
+   * The database to upload the generated documents to. Defaults to `medic`.
+   */
+  db?: string;
+
+  /**
+   * Required. Returns the document to generate. If no `_id` value is provided, one will be generated automatically.
+   * This function is called the number of times defined in the `amount` property.
    * @returns the document to generate
    */
   getDoc(): Doc;

--- a/src/docs.ts
+++ b/src/docs.ts
@@ -1,10 +1,11 @@
 import axios from 'axios';
 import { v4 as uuid } from 'uuid';
 import { DocType, Parent, Doc } from './doc-design.js';
+import { environment } from './environment.js';
 
 export class Docs {
-  private static async saveDocs(docs) {
-    const path = `${process.env.COUCH_URL}/_bulk_docs`;
+  private static async saveDocs(docs, dbName = 'medic') {
+    const path = `${environment.getChtUrl()}/${dbName}/_bulk_docs`;
     try {
       await axios.post(path, { docs });
       console.info(`Successfully saved ${docs.length} docs.`);
@@ -34,7 +35,7 @@ export class Docs {
           };
         });
 
-      const parentDocsPromise = Docs.saveDocs(batch.map(entity => entity.doc));
+      const parentDocsPromise = Docs.saveDocs(batch.map(entity => entity.doc), design.db);
       return parentDocsPromise.then(() => Promise.all(
         batch
           .filter(entity => entity.doc.type !== DocType.dataRecord && entity.design.children)

--- a/src/environment.ts
+++ b/src/environment.ts
@@ -4,7 +4,7 @@ const getChtUrl = () => {
   }
   const match = /(https?:\/\/[^/]+)/i.exec(process.env.COUCH_URL);
   if (!match) {
-    throw new Error('Failed to parse COUCH_URL.');
+    throw new Error(`Failed to parse COUCH_URL [${process.env.COUCH_URL}].`);
   }
   return match[1];
 };
@@ -12,7 +12,7 @@ const getChtUrl = () => {
 const getUsername = () => {
   const match = /https?:\/\/(.*):.*@.*/.exec(getChtUrl());
   if (!match) {
-    console.error('Failed to parse username from COUCH_URL.');
+    console.error(`Failed to parse username from COUCH_URL [${getChtUrl()}].`);
     return null;
   }
   return match[1];

--- a/src/environment.ts
+++ b/src/environment.ts
@@ -1,0 +1,24 @@
+const getChtUrl = () => {
+  if (!process.env.COUCH_URL) {
+    throw new Error('COUCH_URL environment variable must be set.');
+  }
+  const match = /(https?:\/\/[^/]+)/i.exec(process.env.COUCH_URL);
+  if (!match) {
+    throw new Error('Failed to parse COUCH_URL.');
+  }
+  return match[1];
+};
+
+const getUsername = () => {
+  const match = /https?:\/\/(.*):.*@.*/.exec(getChtUrl());
+  if (!match) {
+    console.error('Failed to parse username from COUCH_URL.');
+    return null;
+  }
+  return match[1];
+};
+
+export const environment = {
+  getChtUrl,
+  getUsername,
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,12 +1,16 @@
 import { Docs } from './docs.js';
 import * as path from 'node:path';
 import { DocDesign } from './doc-design.js';
-import { getContext } from './design-context.js';
+import { context } from './design-context.js';
 
 (async function() {
-  const args = process.argv.slice(2);
-  const designScriptPath = path.resolve(args[0]);
-  const getDesign: DocDesign = (await import(designScriptPath)).default;
-  const context= getContext();
-  Docs.createDocs(getDesign(context));
+  try {
+    const args = process.argv.slice(2);
+    const designScriptPath = path.resolve(args[0]);
+    const getDesign: DocDesign = (await import(designScriptPath)).default;
+    Docs.createDocs(getDesign(context.get()));
+  } catch (error) {
+    console.error('ERROR: ', error.message || error);
+    process.exit(1);
+  }
 })();

--- a/tests/design-context.spec.ts
+++ b/tests/design-context.spec.ts
@@ -1,43 +1,24 @@
 import { expect } from 'chai';
 import * as Sinon from 'sinon';
 import { restore, stub } from 'sinon';
-import { getContext } from '../src/design-context.js';
+import { context } from '../src/design-context.js';
+import { environment } from '../src/environment.js';
 
 describe('DesignContext', () => {
-  let couchURL: string;
-  let consoleErrorStub: Sinon.SinonStub;
+  let getUsernameStub: Sinon.SinonStub;
 
-  before(() => couchURL = process.env.COUCH_URL);
-  after(() => process.env.COUCH_URL = couchURL);
-
-  beforeEach(() => consoleErrorStub = stub(console, 'error'));
+  beforeEach(() => getUsernameStub = stub(environment, 'getUsername'));
   afterEach(() => restore());
 
-  [
-    'http://admin:password@localhost:5984',
-    'https://admin:password@localhost:5984',
-  ].forEach(couchURL => {
-    it(`should include username from COUCH_URL (${couchURL})`, async () => {
-      process.env.COUCH_URL = couchURL;
-
-      const context = getContext();
-
-      expect(context).to.deep.equal({ username: 'admin' });
-    });
+  it('should return a context with the username when getUsername returns a username', () => {
+    getUsernameStub.returns('admin');
+    const designContext = context.get();
+    expect(designContext).to.deep.equal({ username: 'admin' });
   });
 
-  [
-    'http://localhost:5984',
-    null
-  ].forEach(couchURL => {
-    it('should include null username when not included in COUCH_URL', async () => {
-      process.env.COUCH_URL = couchURL;
-
-      const context = getContext();
-
-      expect(context).to.deep.equal({ username: null });
-      expect(consoleErrorStub.calledOnce).to.be.true;
-      expect(consoleErrorStub.args[0]).to.deep.equal(['Failed to parse username from COUCH_URL.']);
-    });
+  it('should return a context with null username when getUsername returns null', () => {
+    getUsernameStub.returns(null);
+    const designContext = context.get();
+    expect(designContext).to.deep.equal({ username: null });
   });
 });

--- a/tests/docs.spec.ts
+++ b/tests/docs.spec.ts
@@ -28,7 +28,7 @@ describe('Docs', () => {
     const houseDoc = { _id: 'house-x', type: 'house', name: 'Green House' };
 
     const designs = [
-      { amount: 2, getDoc: () => reportDoc },
+      { amount: 2, db: 'medic-users-meta', getDoc: () => reportDoc },
       {
         amount: 1,
         getDoc: () => hospitalDoc,
@@ -72,7 +72,8 @@ describe('Docs', () => {
       .catch(() => assert('Should have not thrown error.'));
 
     expect(axiosPostStub.callCount).to.equal(12);
-    axiosPostStub.args.forEach(call => expect(call[0]).to.contain('/_bulk_docs'));
+    expect(axiosPostStub.args[0][0]).to.contain('/medic-users-meta/_bulk_docs');
+    axiosPostStub.args.slice(1).forEach(call => expect(call[0]).to.contain('/medic/_bulk_docs'));
     expect(axiosPostStub.args[0][1]).to.deep.equal({
       docs: Array(2).fill({ ...reportDoc }),
     });

--- a/tests/docs.spec.ts
+++ b/tests/docs.spec.ts
@@ -4,6 +4,7 @@ import { stub, restore, resetHistory } from 'sinon';
 
 import { Docs } from '../src/docs.js';
 import { DocType } from '../src/doc-design.js';
+import { environment } from '../src/environment.js';
 
 describe('Docs', () => {
   let axiosPostStub;
@@ -11,6 +12,7 @@ describe('Docs', () => {
   let consoleWarnStub;
 
   beforeEach(() => {
+    stub(environment, 'getChtUrl').returns('http://localhost:5988');
     axiosPostStub = stub(axios, 'post').resolves();
     consoleErrorStub = stub(console, 'error');
     consoleWarnStub = stub(console, 'warn');

--- a/tests/environment.spec.ts
+++ b/tests/environment.spec.ts
@@ -27,7 +27,7 @@ describe('environment', () => {
     ].forEach(couchURL => {
       it('should throw an error when COUCH_URL does not match the expected format', () => {
         process.env.COUCH_URL = couchURL;
-        expect(environment.getChtUrl).to.throw('Failed to parse COUCH_URL.');
+        expect(environment.getChtUrl).to.throw(`Failed to parse COUCH_URL [${couchURL}].`);
       });
     });
 
@@ -62,7 +62,8 @@ describe('environment', () => {
       const context = environment.getUsername();
       expect(context).to.be.null;
       expect(consoleErrorStub.calledOnce).to.be.true;
-      expect(consoleErrorStub.args[0]).to.deep.equal(['Failed to parse username from COUCH_URL.']);
+      expect(consoleErrorStub.args[0]).to.deep
+        .equal([`Failed to parse username from COUCH_URL [${environment.getChtUrl()}].`]);
     });
   });
 });

--- a/tests/environment.spec.ts
+++ b/tests/environment.spec.ts
@@ -1,0 +1,68 @@
+import { expect } from 'chai';
+import * as Sinon from 'sinon';
+import { restore, stub } from 'sinon';
+import { environment } from '../src/environment.js';
+
+describe('environment', () => {
+  let couchURL: string;
+  let consoleErrorStub: Sinon.SinonStub;
+
+  before(() => couchURL = process.env.COUCH_URL);
+  after(() => process.env.COUCH_URL = couchURL);
+
+  beforeEach(() => consoleErrorStub = stub(console, 'error'));
+  afterEach(() => restore());
+
+  describe('getChtUrl', () => {
+    it('should throw an error when COUCH_URL is not set', () => {
+      process.env.COUCH_URL = '';
+      expect(environment.getChtUrl).to.throw('COUCH_URL environment variable must be set.');
+    });
+
+    [
+      'invalid_url',
+      'admin:password@localhost:5984',
+      'localhost:5984',
+      'http:///admin:password@localhost:5984'
+    ].forEach(couchURL => {
+      it('should throw an error when COUCH_URL does not match the expected format', () => {
+        process.env.COUCH_URL = couchURL;
+        expect(environment.getChtUrl).to.throw('Failed to parse COUCH_URL.');
+      });
+    });
+
+    [
+      ['http://admin:password@localhost:5984', 'http://admin:password@localhost:5984'],
+      ['https://root:root@google.com/', 'https://root:root@google.com'],
+      ['http://admin:password@localhost:5984/medic', 'http://admin:password@localhost:5984'],
+      ['https://root:root@google.com/somewhere/else', 'https://root:root@google.com'],
+    ].forEach(([couchURL, expected]) => {
+      it('should return the base URL when COUCH_URL is valid', () => {
+        process.env.COUCH_URL = couchURL;
+        const result = environment.getChtUrl();
+        expect(result).to.equal(expected);
+      });
+    });
+  });
+
+  describe('getUsername', () => {
+    [
+      'http://admin:password@localhost:5984',
+      'https://admin:password@localhost:5984',
+    ].forEach(couchURL => {
+      it(`should include username from COUCH_URL (${couchURL})`, async () => {
+        process.env.COUCH_URL = couchURL;
+        const context = environment.getUsername();
+        expect(context).to.equal('admin');
+      });
+    });
+
+    it('should include null username when not included in COUCH_URL', async () => {
+      process.env.COUCH_URL = 'http://localhost:5984';
+      const context = environment.getUsername();
+      expect(context).to.be.null;
+      expect(consoleErrorStub.calledOnce).to.be.true;
+      expect(consoleErrorStub.args[0]).to.deep.equal(['Failed to parse username from COUCH_URL.']);
+    });
+  });
+});


### PR DESCRIPTION
Supports writing docs to other databases besides just `medic`.  Adds a new optional `db: string` field to the `DesignSpec` interface that can be set to the name of the db to write the doc to (e.g. `medic-users-meta`).


Also closes #5