### PR TITLE
feat(#4): make errors useful

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,11 +82,6 @@ Based on that previous example. The tool will create and push 14 report docs at 
 
 See the [sample-designs](./sample-designs) folder for more examples.
 
-## Knows and TODOs
-
-- Make test data samples for CHT's "default" config so we can use copy from there as a base. 
-- Make a `getContact(doc._id)` function, to get an existing contact's information (name, etc.) and use it in new test data (right we need to hard code existing contact information).
-
 ## License
 
 This project is licensed under the GNU GPLv3 License - see the LICENSE.md file for details

--- a/sample-designs/add-to-existing-hierarchy.js
+++ b/sample-designs/add-to-existing-hierarchy.js
@@ -72,6 +72,7 @@ const PATIENT_UUID = '56bfecd7-7f14-4e74-8103-d227400b28ce';
 export default (context) => {
   return [
     {
+      id: 'chw-supervisor',
       amount: 1,
       getDoc: () => {
         return {
@@ -81,6 +82,7 @@ export default (context) => {
       },
     },
     {
+      id:'pregnancy-danger-report',
       amount: 1,
       getDoc: () => {
         return {

--- a/sample-designs/add-to-existing-hierarchy.js
+++ b/sample-designs/add-to-existing-hierarchy.js
@@ -72,7 +72,7 @@ const PATIENT_UUID = '56bfecd7-7f14-4e74-8103-d227400b28ce';
 export default (context) => {
   return [
     {
-      id: 'chw-supervisor',
+      designId: 'chw-supervisor',
       amount: 1,
       getDoc: () => {
         return {
@@ -82,7 +82,7 @@ export default (context) => {
       },
     },
     {
-      id:'pregnancy-danger-report',
+      designId:'pregnancy-danger-report',
       amount: 1,
       getDoc: () => {
         return {

--- a/sample-designs/default.js
+++ b/sample-designs/default.js
@@ -97,39 +97,46 @@ const getPregnancyDangerSign = () => {
 export default (context) => {
   return [
     {
+      id: 'district-hospital',
       amount: 2,
       getDoc: () => getDistrictHospital(context),
       children: [
         {
+          id: 'health-center',
           amount: 2,
           getDoc: () => getHealthCenter(context),
           children: [
             {
+              id: 'household',
               amount: 2,
               getDoc: () => getHousehold(context),
               children: [
                 {
+                  id: 'woman-person',
                   amount: 1,
                   getDoc: () => getWoman(context),
                   children: [
                     {
+                      id: 'pregnancy-danger-report',
                       amount: 1,
                       getDoc: () => getPregnancyDangerSign(),
                     }
                   ]
                 },
-                { amount: 2, getDoc: () => getChild(context) },
-                { amount: 1, getDoc: () => getInfant(context) },
-                { amount: 2, getDoc: () => getPatient(context) }
+                { id: 'child-person', amount: 2, getDoc: () => getChild(context) },
+                { id: 'infant-person', amount: 1, getDoc: () => getInfant(context) },
+                { id: 'patient-person', amount: 2, getDoc: () => getPatient(context) }
               ]
             },
             {
+              id: 'chw',
               amount: 1,
               getDoc: () => getCHW(context),
             }
           ]
         },
         {
+          id: 'chw-supervisor',
           amount: 1,
           getDoc: () => getCHWSupervisor(context),
         }

--- a/sample-designs/default.js
+++ b/sample-designs/default.js
@@ -97,46 +97,46 @@ const getPregnancyDangerSign = () => {
 export default (context) => {
   return [
     {
-      id: 'district-hospital',
+      designId: 'district-hospital',
       amount: 2,
       getDoc: () => getDistrictHospital(context),
       children: [
         {
-          id: 'health-center',
+          designId: 'health-center',
           amount: 2,
           getDoc: () => getHealthCenter(context),
           children: [
             {
-              id: 'household',
+              designId: 'household',
               amount: 2,
               getDoc: () => getHousehold(context),
               children: [
                 {
-                  id: 'woman-person',
+                  designId: 'woman-person',
                   amount: 1,
                   getDoc: () => getWoman(context),
                   children: [
                     {
-                      id: 'pregnancy-danger-report',
+                      designId: 'pregnancy-danger-report',
                       amount: 1,
                       getDoc: () => getPregnancyDangerSign(),
                     }
                   ]
                 },
-                { id: 'child-person', amount: 2, getDoc: () => getChild(context) },
-                { id: 'infant-person', amount: 1, getDoc: () => getInfant(context) },
-                { id: 'patient-person', amount: 2, getDoc: () => getPatient(context) }
+                { designId: 'child-person', amount: 2, getDoc: () => getChild(context) },
+                { designId: 'infant-person', amount: 1, getDoc: () => getInfant(context) },
+                { designId: 'patient-person', amount: 2, getDoc: () => getPatient(context) }
               ]
             },
             {
-              id: 'chw',
+              designId: 'chw',
               amount: 1,
               getDoc: () => getCHW(context),
             }
           ]
         },
         {
-          id: 'chw-supervisor',
+          designId: 'chw-supervisor',
           amount: 1,
           getDoc: () => getCHWSupervisor(context),
         }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,0 +1,30 @@
+import { resolve, extname } from 'node:path';
+import { existsSync } from 'node:fs';
+
+const SUPPORTED_INPUT_FILE = '.js';
+
+const getInputFilePath = () => {
+  const args = process.argv.slice(2);
+  if (!args?.length) {
+    throw new Error(
+      'No path to the design file provided. Expected: npm run generate *path_to_your_custom_design_file*'
+    );
+  }
+
+  const path = resolve(args[0]);
+  if (extname(path) !== SUPPORTED_INPUT_FILE) {
+    throw new Error(
+      'The design file is not a JavaScript file. Retry using a file with extension ending in .js'
+    );
+  }
+
+  if (!existsSync(path)) {
+    throw new Error('The design file does not exist in the specified location. Verify the path is correct.');
+  }
+
+  return path;
+};
+
+export const cli = {
+  getInputFilePath,
+};

--- a/src/doc-design.ts
+++ b/src/doc-design.ts
@@ -20,6 +20,11 @@ export type DocDesign = (context: DesignContext) => DesignSpec[];
  */
 export interface DesignSpec {
   /**
+   * Optional. Useful for debugging and to identify if the upload was successful or failed.
+   */
+  id?: string;
+
+  /**
    * Required. The number of documents of this type to generate. This also servers as the batch size of docs to upload.
    */
   amount: number;

--- a/src/doc-design.ts
+++ b/src/doc-design.ts
@@ -20,9 +20,9 @@ export type DocDesign = (context: DesignContext) => DesignSpec[];
  */
 export interface DesignSpec {
   /**
-   * Optional. Useful for debugging and to identify if the upload was successful or failed.
+   * Optional. Useful for debugging and to identify if the upload was successful or failed. Defaults to index in array.
    */
-  id?: string;
+  designId?: string;
 
   /**
    * Required. The number of documents of this type to generate. This also servers as the batch size of docs to upload.

--- a/src/docs.ts
+++ b/src/docs.ts
@@ -4,20 +4,20 @@ import { DocType, Parent, Doc } from './doc-design.js';
 import { environment } from './environment.js';
 
 export class Docs {
-  private static async saveDocs(docs, dbName = 'medic') {
+  private static async saveDocs(docs, dbName = 'medic', batchId) {
     const path = `${environment.getChtUrl()}/${dbName}/_bulk_docs`;
     try {
       await axios.post(path, { docs });
-      console.info(`Successfully saved ${docs.length} docs.`);
+      console.info(`Successfully saved ${docs.length} docs from ${batchId}.`);
     } catch (error) {
-      console.error('Failed saving docs ::>', error);
+      console.error(`Failed saving docs from ${batchId}. Errors: `, error.message || error.errors || error);
     }
   }
 
   static createDocs(designs, parentDoc?: Doc) {
     return designs.map(design => {
       if (!design.amount || !design.getDoc) {
-        console.warn('Remember to set the "amount" and the "getDoc".');
+        console.warn(`Remember to set the "amount" and the "getDoc" in ${design.id}.`);
         return;
       }
 
@@ -35,7 +35,7 @@ export class Docs {
           };
         });
 
-      const parentDocsPromise = Docs.saveDocs(batch.map(entity => entity.doc), design.db);
+      const parentDocsPromise = Docs.saveDocs(batch.map(entity => entity.doc), design.db, design.id);
       return parentDocsPromise.then(() => Promise.all(
         batch
           .filter(entity => entity.doc.type !== DocType.dataRecord && entity.design.children)

--- a/src/docs.ts
+++ b/src/docs.ts
@@ -15,9 +15,13 @@ export class Docs {
   }
 
   static createDocs(designs, parentDoc?: Doc) {
-    return designs.map(design => {
+    return designs.map((design, index) => {
+      if (!design.designId) {
+        design.designId = index;
+      }
+
       if (!design.amount || !design.getDoc) {
-        console.warn(`Remember to set the "amount" and the "getDoc" in ${design.id}.`);
+        console.warn(`Remember to set the "amount" and the "getDoc" in ${design.designId}.`);
         return;
       }
 
@@ -35,7 +39,7 @@ export class Docs {
           };
         });
 
-      const parentDocsPromise = Docs.saveDocs(batch.map(entity => entity.doc), design.db, design.id);
+      const parentDocsPromise = Docs.saveDocs(batch.map(entity => entity.doc), design.db, design.designId);
       return parentDocsPromise.then(() => Promise.all(
         batch
           .filter(entity => entity.doc.type !== DocType.dataRecord && entity.design.children)

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,12 +1,11 @@
+import { cli } from './cli.js';
 import { Docs } from './docs.js';
-import * as path from 'node:path';
 import { DocDesign } from './doc-design.js';
 import { context } from './design-context.js';
 
 (async function() {
   try {
-    const args = process.argv.slice(2);
-    const designScriptPath = path.resolve(args[0]);
+    const designScriptPath = cli.getInputFilePath();
     const getDesign: DocDesign = (await import(designScriptPath)).default;
     Docs.createDocs(getDesign(context.get()));
   } catch (error) {

--- a/tests/cli.spec.ts
+++ b/tests/cli.spec.ts
@@ -1,0 +1,77 @@
+import { resolve } from 'node:path';
+import { expect, assert } from 'chai';
+import * as Sinon from 'sinon';
+import { restore, stub } from 'sinon';
+import { cli } from '../src/cli.js';
+
+describe('cli', () => {
+  let argvStub: Sinon.SinonStub;
+
+  beforeEach(() => {
+    argvStub = stub(process, 'argv');
+  });
+
+  afterEach(() => restore());
+
+  describe('getInputFilePath', () => {
+    it('should return the design file path successfully', () => {
+      try {
+        argvStub.get(() => [ 'node-path', 'application-entry', 'tests/files/empty-design-file.js' ]);
+
+        const path = cli.getInputFilePath();
+
+        expect(path).to.equal(resolve('tests/files/empty-design-file.js'));
+      } catch (error) {
+        assert.fail('Should have not thrown an error');
+      }
+    });
+
+    it('should throw an error when design file does not exist in path', () => {
+      try {
+        argvStub.get(() => [ 'node-path', 'application-entry', 'tests/files/no-existing.js' ]);
+
+        cli.getInputFilePath();
+
+        assert.fail('Should have thrown an error');
+      } catch (error) {
+        expect(error?.message).to.equal(
+          'The design file does not exist in the specified location. Verify the path is correct.'
+        );
+      }
+    });
+
+    [
+      'folder/file-no-extension',
+      'folder/file-wrong-extension.svg',
+      'file-wrong-extension.ts',
+    ].forEach(filePath => {
+      it('should throw an error when the design file path has the wrong extension', () => {
+        try {
+          argvStub.get(() => [ 'node-path', 'application-entry', filePath ]);
+
+          cli.getInputFilePath();
+
+          assert.fail('Should have thrown an error');
+        } catch (error) {
+          expect(error?.message).to.equal(
+            'The design file is not a JavaScript file. Retry using a file with extension ending in .js'
+          );
+        }
+      });
+    });
+
+    it('should throw an error when design file path is not provided', () => {
+      try {
+        argvStub.get(() => [ 'node-path', 'application-entry' ]);
+
+        cli.getInputFilePath();
+
+        assert.fail('Should have thrown an error');
+      } catch (error) {
+        expect(error?.message).to.equal(
+          'No path to the design file provided. Expected: npm run generate *path_to_your_custom_design_file*'
+        );
+      }
+    });
+  });
+});

--- a/tests/docs.spec.ts
+++ b/tests/docs.spec.ts
@@ -30,21 +30,21 @@ describe('Docs', () => {
     const houseDoc = { _id: 'house-x', type: 'house', name: 'Green House' };
 
     const designs = [
-      { id: 'design-1', amount: 2, db: 'medic-users-meta', getDoc: () => reportDoc },
+      { designId: 'design-1', amount: 2, db: 'medic-users-meta', getDoc: () => reportDoc },
       {
-        id: 'design-2',
+        designId: 'design-2',
         amount: 1,
         getDoc: () => hospitalDoc,
         children: [
           {
-            id: 'design-2-1',
+            designId: 'design-2-1',
             amount: 1,
             getDoc: () => unitDoc,
             children: [
-              { id: 'design-2-1-1', amount: 3, getDoc: () => clinicDoc },
-              { id: 'design-2-1-2', amount: 3, getDoc: () => personDoc },
+              { designId: 'design-2-1-1', amount: 3, getDoc: () => clinicDoc },
+              { designId: 'design-2-1-2', amount: 3, getDoc: () => personDoc },
               {
-                id: 'design-2-1-3',
+                designId: 'design-2-1-3',
                 amount: 1,
                 getDoc: () => houseDoc,
                 children: [
@@ -150,24 +150,24 @@ describe('Docs', () => {
 
     const designs = [
       {
-        id: 'design-1',
+        designId: 'design-1',
         amount: 1,
         getDoc: () => hospitalDoc,
         children: [
-          { id: 'design-1-1', amount: 4, getDoc: () => unitDoc },
+          { designId: 'design-1-1', amount: 4, getDoc: () => unitDoc },
           {
-            id: 'design-1-2',
+            designId: 'design-1-2',
             amount: 13,
             getDoc: () => ({ ...centerDoc, parent: { _id: '009' } }),
           },
         ],
       },
       {
-        id: 'design-2',
+        designId: 'design-2',
         amount: 3,
         getDoc: () => ({ ...centerDoc, parent: { _id: '007' } }),
         children: [
-          { id: 'design-2-1', amount: 7, getDoc: () => unitDoc }
+          { designId: 'design-2-1', amount: 7, getDoc: () => unitDoc }
         ],
       },
     ];
@@ -205,7 +205,7 @@ describe('Docs', () => {
 
   it('should generate _id value if none is provided', async () => {
     const hospitalDoc = { type: 'hospital', name: 'Green Hospital' };
-    const designs = [{ id: 'design-1', amount: 1, getDoc: () => hospitalDoc },];
+    const designs = [{ designId: 'design-1', amount: 1, getDoc: () => hospitalDoc },];
 
     await Promise
       .all(Docs.createDocs(designs))
@@ -264,7 +264,7 @@ describe('Docs', () => {
     const parent = { _id: 'parentUUID', type: 'clinic' };
     const doc = { _id: 'doc-x', type: DocType.person, parent: { _id: 'otherParent' } };
     const designs = [{
-      id: 'design-1',
+      designId: 'design-1',
       amount: 1,
       getDoc: () => parent,
       children: [{ amount: 1, getDoc: () => doc } ],
@@ -318,8 +318,8 @@ describe('Docs', () => {
 
   it('should warn if amount or getDoc are missing', async () => {
     let designs = [
-      { id: 'design-1' },
-      { id: 'design-2', amount: 2, getDoc: () => ({ _id: '124', type: 'hospital' }) },
+      { designId: 'design-1' },
+      { designId: 'design-2', amount: 2, getDoc: () => ({ _id: '124', type: 'hospital' }) },
     ];
 
     await Promise
@@ -333,11 +333,11 @@ describe('Docs', () => {
     resetHistory();
     designs = [
       {
-        id: 'design-1',
+        designId: 'design-1',
         amount: 2,
         getDoc: () => ({ _id: '124', type: 'clinic' }),
         // @ts-expect-error children property is not on type
-        children: [ { id: 'design-1-1', amount: 3 }, { id: 'design-1-2', getDoc: () => {} } ],
+        children: [ { designId: 'design-1-1', amount: 3 }, { designId: 'design-1-2', getDoc: () => {} } ],
       },
     ];
 
@@ -349,7 +349,7 @@ describe('Docs', () => {
 
     resetHistory();
     designs = [{
-      id: 'design-1',
+      designId: 'design-1',
       amount: 0,
       getDoc: () => ({ _id: '124', type: 'clinic' }),
     }];
@@ -363,7 +363,7 @@ describe('Docs', () => {
 
   it('should catch errors when saving docs', async () => {
     const designs = [
-      { id: 'design-1', amount: 2, getDoc: () => ({ _id: '124', type: 'hospital' }) },
+      { designId: 'design-1', amount: 2, getDoc: () => ({ _id: '124', type: 'hospital' }) },
     ];
     const error = new Error('Ups something happened');
     axiosPostStub.rejects(error);
@@ -378,12 +378,12 @@ describe('Docs', () => {
   it('should catch errors when saving docs, but continue saving other batches', async () => {
     const designs = [
       {
-        id: 'design-1',
+        designId: 'design-1',
         amount: 2,
         getDoc: () => ({ _id: '124', type: 'ward-b' })
       },
       {
-        id: 'design-2',
+        designId: 'design-2',
         amount: 2,
         getDoc: () => ({ _id: '888', type: 'ward-a' })
       },


### PR DESCRIPTION
- Adds validation to the CLI's input.
  - But for now, it's not validating if the file is empty; for that, it'd need to load the whole file in memory (which we are already with the `import`). 
- Adds an optional ID property for each design object. The primary use case is when uploading too many batches at a time, the CHT/CouchDB rejects the requests (rate limit?); it is helpful to know which batches failed and retry those. 