### PR TITLE
fix(#9) - deeper parent map

### DIFF
--- a/src/doc-design.ts
+++ b/src/doc-design.ts
@@ -48,7 +48,7 @@ export interface DesignSpec {
 
 export interface Parent {
   _id: string,
-  parent?: Record<string, string>
+  parent?: Parent
 }
 
 export interface Doc {

--- a/src/docs.ts
+++ b/src/docs.ts
@@ -44,17 +44,21 @@ export class Docs {
     });
   }
 
-  private static createParentRelation(parentDoc: Doc): Parent {
+  private static createParentRelation(parentDoc: Doc | Parent): Parent {
     if (!parentDoc) {
       return;
     }
 
-    const parent: Parent = { _id: parentDoc._id };
-    if (parentDoc.parent) {
-      parent.parent = { _id: parentDoc.parent._id };
+    const result: Parent = { _id: parentDoc._id };
+    let minified: Parent = result;
+
+    while (parentDoc.parent) {
+      minified.parent = { _id: parentDoc.parent._id };
+      minified = minified.parent;
+      parentDoc = parentDoc.parent;
     }
 
-    return parent;
+    return result;
   }
 
   private static getPatientPlaceIdentifiers(parentDoc: Doc) {

--- a/tests/docs.spec.ts
+++ b/tests/docs.spec.ts
@@ -128,14 +128,14 @@ describe('Docs', () => {
     expect(axiosPostStub.args[10][1]).to.deep.equal({
       docs: Array(2).fill({
         ...personDoc,
-        parent: { _id: houseDoc._id, parent: { _id: unitDoc._id } },
+        parent: { _id: houseDoc._id, parent: { _id: unitDoc._id, parent: { _id: hospitalDoc._id } } },
       }),
     });
 
     expect(axiosPostStub.args[11][1]).to.deep.equal({
       docs: Array(10).fill({
         ...personDoc,
-        parent: { _id: houseDoc._id, parent: { _id: centerDoc._id } },
+        parent: { _id: houseDoc._id, parent: { _id: centerDoc._id, parent: { _id: hospitalDoc._id } } },
       }),
     });
   });
@@ -250,7 +250,7 @@ describe('Docs', () => {
     }] });
     expect(axiosPostStub.args[3][1]).to.deep.equal({ docs: [{
       ...doc,
-      parent: { _id: parent._id, parent: { _id: grandParent._id } }
+      parent: { _id: parent._id, parent: { _id: grandParent._id, parent: { _id: greatGrandParent._id } } }
     }] });
   });
 


### PR DESCRIPTION
Allows associating contacts and reports to existing contacts with a big hierarchy 
should work with 3 to 6 or more levels. 