### PR TITLE
feat(#2): pass parent doc when getting new doc from design

### DIFF
--- a/sample-designs/default.js
+++ b/sample-designs/default.js
@@ -61,7 +61,7 @@ const getWoman = context => getPerson(context, 'patient', { sex: 'female', ageRa
 const getChild = context => getPerson(context, 'patient', { ageRange: { min: 0, max: 14 } });
 const getInfant = context => getPerson(context, 'patient', { ageRange: { min: 0, max: 1 } });
 
-const getPregnancyDangerSign = () => {
+const getPregnancyDangerSign = (patient) => {
   return {
     form: 'pregnancy_danger_sign',
     type: 'data_record',
@@ -69,7 +69,7 @@ const getPregnancyDangerSign = () => {
     reported_date: faker.date.recent({ days: 5 }).getTime(),
     fields: {
       patient_age_in_years: 34,
-      patient_name: 'Erick Loral',
+      patient_name: patient.name,
       t_danger_signs_referral_follow_up_date: faker.date.recent({ days: 5 }).toISOString(),
       t_danger_signs_referral_follow_up: 'yes', // Intentionally 'yes'
       danger_signs: {
@@ -114,7 +114,7 @@ export default (context) => {
                   children: [
                     {
                       amount: 1,
-                      getDoc: () => getPregnancyDangerSign(),
+                      getDoc: ({parent}) => getPregnancyDangerSign(parent),
                     }
                   ]
                 },

--- a/src/doc-design.ts
+++ b/src/doc-design.ts
@@ -32,9 +32,10 @@ export interface DesignSpec {
   /**
    * Required. Returns the document to generate. If no `_id` value is provided, one will be generated automatically.
    * This function is called the number of times defined in the `amount` property.
+   * @param args.parent the newly created parent document if one exists, otherwise undefined
    * @returns the document to generate
    */
-  getDoc(): Doc;
+  getDoc(args: { parent?: Doc }): Doc;
 
   /**
    * Defines the children documents that should be created for the current document type. These children will be

--- a/src/docs.ts
+++ b/src/docs.ts
@@ -24,7 +24,7 @@ export class Docs {
       const batch = new Array(design.amount)
         .fill(null)
         .map(() => {
-          const doc = design.getDoc();
+          const doc = design.getDoc({ parent: parentDoc });
           return {
             design,
             doc: {

--- a/tests/docs.spec.ts
+++ b/tests/docs.spec.ts
@@ -197,6 +197,30 @@ describe('Docs', () => {
     });
   });
 
+  it('should provide the parent doc value when getting a new doc from the design', async () => {
+    const hospitalDoc = { _id: 'hospital-x', type: 'hospital', name: 'Green Hospital' };
+    const getHospitalDoc = stub().returns(hospitalDoc);
+    const getCenterDoc = stub().returns({ _id: 'center-x', type: 'center', name: 'Green Health Center' });
+    const designs = [{
+      amount: 1,
+      getDoc: getHospitalDoc,
+      children: [{
+        amount: 1,
+        getDoc: getCenterDoc,
+      }]
+    },];
+
+    await Promise
+      .all(Docs.createDocs(designs))
+      .catch(() => assert('Should have not thrown error.'));
+
+    expect(axiosPostStub.callCount).to.equal(2);
+    expect(getHospitalDoc.calledOnce).to.be.true;
+    expect(getHospitalDoc.args[0][0]).to.deep.equal({ parent: undefined });
+    expect(getCenterDoc.calledOnce).to.be.true;
+    expect(getCenterDoc.args[0][0]).to.deep.equal({ parent: hospitalDoc });
+  });
+
   it('should generate _id value if none is provided', async () => {
     const hospitalDoc = { type: 'hospital', name: 'Green Hospital' };
     const designs = [{ amount: 1, getDoc: () => hospitalDoc },];


### PR DESCRIPTION
The main value this should provide is when using something like `faker` to auto-generate data that we want to reference from child docs (e.g. generate the name of a contact, and then write reports for that contact that contain the contact's name value).

Closes #2 