### PR TITLE
fix(#21): batch docwrites to minimize time spent on POST calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,23 @@ Based on that previous example. The tool will create and push 14 report docs at 
 
 See the [sample-designs](./sample-designs) folder for more examples.
 
+## Performance considerations
+
+Many factors can affect the performance of the generator including the number of documents to generate, the size of the documents, the network speed, and the server's performance. When adding large datasets (100,000+ documents) to a database with existing views (e.g. the `medic` database), Couch's view indexing jobs can significantly impact the performance of the generator.
+
+Under optimal conditions, running against a local CouchDB instance and inserting data into a new database with no views, the document creation rate has been measured at `~360,000 docs/min`.  
+
+However, when running against a local CouchDB instance and inserting data into an existing `medic` database, the measured document creation rate was `~8000 docs/min`.
+
+### Generate then replicate
+
+When generating a massive dataset (100,000+ documents) for an existing database with views (e.g. the `medic` database), it may be preferable to actually generate the data into a temporary database (on the same CouchDB instance) and then replicate the data into the target database (e.g. using Fauxton). The document creation rate for this process (including generating into the temp db, replicating to `medic` db, and indexing views) has been measured at `~11,000 docs/min`.
+
+While the speed gains of this approach are somewhat modest, it has a couple additional benefits:
+
+- The time spent running the actual generation script is minimal (since docs are added to the temp db at `~360,000 docs/min`). So, there is less danger of the script being interrupted or becoming disconnected from the CouchDB instance. Once all the docs are saved in the temp db, the replication/indexing happen internally within the Couch instance. This is where the vast majority of the time is spent.
+- You can keep your generated dataset in the temp db for future use, without having to regenerate it each time you want to test with it.
+
 ## License
 
 This project is licensed under the GNU GPLv3 License - see the LICENSE.md file for details

--- a/README.md
+++ b/README.md
@@ -104,12 +104,12 @@ However, when running against a local CouchDB instance and inserting data into a
 
 ### Generate then replicate
 
-When generating a massive dataset (100,000+ documents) for an existing database with views (e.g. the `medic` database), it may be preferable to actually generate the data into a temporary database (on the same CouchDB instance) and then replicate the data into the target database (e.g. using Fauxton). The document creation rate for this process (including generating into the temp db, replicating to `medic` db, and indexing views) has been measured at `~11,000 docs/min`.
+When generating a massive dataset (100,000+ documents) for an existing database with views (e.g. the `medic` database), it may be preferable to actually generate the data into a temporary database (on the same CouchDB instance) and then replicate the data into the target database (e.g. using Fauxton). The document creation rate for this process (including generating into the temp DB, replicating to `medic` DB, and indexing views) has been measured at `~11,000 docs/min`.
 
 While the speed gains of this approach are somewhat modest, it has a couple additional benefits:
 
-- The time spent running the actual generation script is minimal (since docs are added to the temp db at `~360,000 docs/min`). So, there is less danger of the script being interrupted or becoming disconnected from the CouchDB instance. Once all the docs are saved in the temp db, the replication/indexing happen internally within the Couch instance. This is where the vast majority of the time is spent.
-- You can keep your generated dataset in the temp db for future use, without having to regenerate it each time you want to test with it.
+- The time spent running the actual generation script is minimal (since docs are added to the temp db at `~360,000 docs/min`). So, there is less danger of the script being interrupted or becoming disconnected from the CouchDB instance. Once all the docs are saved in the temp DB, the replication/indexing happens internally within the Couch instance. This is where the vast majority of the time is spent.
+- You can keep your generated dataset in the temp DB for future use, without having to regenerate it each time you want to test with it.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ However, when running against a local CouchDB instance and inserting data into a
 
 ### Generate then replicate
 
-When generating a massive dataset (100,000+ documents) for an existing database with views (e.g. the `medic` database), it may be preferable to actually generate the data into a temporary database (on the same CouchDB instance) and then replicate the data into the target database (e.g. using Fauxton). The document creation rate for this process (including generating into the temp DB, replicating to `medic` DB, and indexing views) has been measured at `~11,000 docs/min`.
+When generating a massive dataset (100,000+ documents) for an existing database with views (e.g. the `medic` database), it may be preferable to actually generate the data into a temporary database (on the same CouchDB instance) and then replicate the data into the target database (e.g. using the Fauxton form at `_utils/#/replication/_create`). The document creation rate for this process (including generating into the temp DB, replicating to `medic` DB, and indexing views) has been measured at `~11,000 docs/min`.
 
 While the speed gains of this approach are somewhat modest, it has a couple additional benefits:
 

--- a/src/doc-writer.ts
+++ b/src/doc-writer.ts
@@ -3,36 +3,39 @@ import { environment } from './environment.js';
 import axios from 'axios';
 
 const BATCH_SIZE = 1000;
+const docsByDb: { [dbName: string]: Doc[] } = {};
 
-export class DocWriter {
-  private docsByDb: { [dbName: string]: Doc[] } = {};
-
-  async write(docs: Doc[], dbName = 'medic'): Promise<void> {
-    if (!this.docsByDb[dbName]) {
-      this.docsByDb[dbName] = [];
+const postDocs = async (dbName: string, remainingLimit = BATCH_SIZE): Promise<void> => {
+  const path = `${environment.getChtUrl()}/${dbName}/_bulk_docs`;
+  do {
+    const docs = docsByDb[dbName].splice(0, BATCH_SIZE);
+    try {
+      await axios.post(path, { docs });
+      console.info(`Successfully wrote ${docs.length} docs to ${dbName}.`);
+    } catch (error) {
+      console.error(`Failed writing docs to ${dbName}. Errors: `, error.message || error.errors || error);
     }
-    this.docsByDb[dbName].push(...docs);
-    if (this.docsByDb[dbName].length >= BATCH_SIZE) {
-      await this.postDocs(dbName);
-    }
-  }
+  } while (docsByDb[dbName].length > remainingLimit);
+};
 
-  async flush(): Promise<void> {
-    for (const dbName of Object.keys(this.docsByDb)) {
-      await this.postDocs(dbName, 0);
-    }
+const write = async (docs: Doc[], dbName = 'medic'): Promise<void> => {
+  if (!docsByDb[dbName]) {
+    docsByDb[dbName] = [];
   }
+  docsByDb[dbName].push(...docs);
+  if (docsByDb[dbName].length >= BATCH_SIZE) {
+    await postDocs(dbName);
+  }
+};
 
-  private async postDocs(dbName: string, remainingLimit = BATCH_SIZE): Promise<void> {
-    const path = `${environment.getChtUrl()}/${dbName}/_bulk_docs`;
-    do {
-      const docs = this.docsByDb[dbName].splice(0, BATCH_SIZE);
-      try {
-        await axios.post(path, { docs });
-        console.info(`Successfully wrote ${docs.length} docs to ${dbName}.`);
-      } catch (error) {
-        console.error(`Failed writing docs to ${dbName}. Errors: `, error.message || error.errors || error);
-      }
-    } while (this.docsByDb[dbName].length > remainingLimit);
+const flush = async (): Promise<void> => {
+  for (const dbName of Object.keys(docsByDb)) {
+    await postDocs(dbName, 0);
+    delete docsByDb[dbName];
   }
-}
+};
+
+export default {
+  write,
+  flush,
+};

--- a/src/doc-writer.ts
+++ b/src/doc-writer.ts
@@ -1,0 +1,38 @@
+import { Doc } from './doc-design.js';
+import { environment } from './environment.js';
+import axios from 'axios';
+
+const BATCH_SIZE = 1000;
+
+export class DocWriter {
+  private docsByDb: { [dbName: string]: Doc[] } = {};
+
+  async write(docs: Doc[], dbName = 'medic'): Promise<void> {
+    if (!this.docsByDb[dbName]) {
+      this.docsByDb[dbName] = [];
+    }
+    this.docsByDb[dbName].push(...docs);
+    if (this.docsByDb[dbName].length >= BATCH_SIZE) {
+      await this.postDocs(dbName);
+    }
+  }
+
+  async flush(): Promise<void> {
+    for (const dbName of Object.keys(this.docsByDb)) {
+      await this.postDocs(dbName, 0);
+    }
+  }
+
+  private async postDocs(dbName: string, remainingLimit = BATCH_SIZE): Promise<void> {
+    const path = `${environment.getChtUrl()}/${dbName}/_bulk_docs`;
+    do {
+      const docs = this.docsByDb[dbName].splice(0, BATCH_SIZE);
+      try {
+        await axios.post(path, { docs });
+        console.info(`Successfully wrote ${docs.length} docs to ${dbName}.`);
+      } catch (error) {
+        console.error(`Failed writing docs to ${dbName}. Errors: `, error.message || error.errors || error);
+      }
+    } while (this.docsByDb[dbName].length > remainingLimit);
+  }
+}

--- a/src/docs.ts
+++ b/src/docs.ts
@@ -1,8 +1,6 @@
 import { v4 as uuid } from 'uuid';
 import { Doc, DocType, Parent } from './doc-design.js';
-import { DocWriter } from './doc-writer.js';
-
-const docWriter = new DocWriter();
+import docWriter from './doc-writer.js';
 
 export class Docs {
   private static async saveDocs(docs, dbName, batchId) {

--- a/tests/doc-writer.spec.ts
+++ b/tests/doc-writer.spec.ts
@@ -1,0 +1,144 @@
+import axios from 'axios';
+import { expect } from 'chai';
+import * as sinon from 'sinon';
+import { SinonStub } from 'sinon';
+import { DocType } from '../src/doc-design.js';
+import { environment } from '../src/environment.js';
+import docWriter from '../src/doc-writer.js';
+
+const BASE_URL = 'http://localhost:5988';
+const BULK_DOCS_PATH = '_bulk_docs';
+const makeReport = (_id: string) => ({ _id, form: 'pregnancy_danger_sign', type: DocType.dataRecord });
+const makeReports = (count: number) => Array.from({ length: count }, (_, i) => makeReport(`report-${i}`));
+const getPostSuccessMsg = (docsLength: number, dbName: string) => `Successfully wrote ${docsLength} docs to ${dbName}.`;
+
+describe('Doc writer', () => {
+  let getChtUrlStub: SinonStub;
+  let postStub: SinonStub;
+  let consoleErrorStub: SinonStub;
+  let consoleInfoStub: SinonStub;
+
+  beforeEach(() => {
+    getChtUrlStub = sinon.stub(environment, 'getChtUrl').returns(BASE_URL);
+    postStub = sinon.stub(axios, 'post').resolves();
+    consoleErrorStub = sinon.stub(console, 'error');
+    consoleInfoStub = sinon.stub(console, 'info');
+  });
+
+  afterEach(async () => {
+    await docWriter.flush();
+    sinon.restore();
+  });
+
+  describe('write', () => {
+    it('immediately POSTs 1000 docs', async () => {
+      const docs = makeReports(1000);
+      const dbName = 'reports';
+
+      await docWriter.write(docs, dbName);
+
+      expect(getChtUrlStub.calledOnceWithExactly()).to.be.true;
+      expect(postStub.calledOnceWithExactly(`${BASE_URL}/${dbName}/${BULK_DOCS_PATH}`, { docs })).to.be.true;
+      expect(consoleErrorStub.notCalled).to.be.true;
+      expect(consoleInfoStub.calledOnceWithExactly(getPostSuccessMsg(docs.length, dbName))).to.be.true;
+    });
+
+    it('immediately POSTs batches of 1000 docs when given more than 1000 docs', async () => {
+      const docs = makeReports(3333);
+      const dbName = 'reports';
+
+      await docWriter.write(docs, dbName);
+
+      expect(getChtUrlStub.calledOnceWithExactly()).to.be.true;
+      expect(postStub.args).to.deep.equal([
+        [`${BASE_URL}/${dbName}/${BULK_DOCS_PATH}`, { docs: docs.slice(0, 1000) }],
+        [`${BASE_URL}/${dbName}/${BULK_DOCS_PATH}`, { docs: docs.slice(1000, 2000) }],
+        [`${BASE_URL}/${dbName}/${BULK_DOCS_PATH}`, { docs: docs.slice(2000, 3000) }],
+      ]);
+      expect(consoleErrorStub.notCalled).to.be.true;
+      expect(consoleInfoStub.args).to.deep.equal([
+        [getPostSuccessMsg(1000, dbName)],
+        [getPostSuccessMsg(1000, dbName)],
+        [getPostSuccessMsg(1000, dbName)]
+      ]);
+    });
+
+    it('defaults to medic database when none is provided', async () => {
+      const docs = makeReports(1000);
+      const dbName = 'medic';
+
+      await docWriter.write(docs);
+
+      expect(getChtUrlStub.calledOnceWithExactly()).to.be.true;
+      expect(postStub.calledOnceWithExactly(`${BASE_URL}/${dbName}/${BULK_DOCS_PATH}`, { docs })).to.be.true;
+      expect(consoleErrorStub.notCalled).to.be.true;
+      expect(consoleInfoStub.calledOnceWithExactly(getPostSuccessMsg(docs.length, dbName))).to.be.true;
+    });
+
+    [0, 1, 999].forEach(count => {
+      it('does not POST when less than 1000 docs are provided', async () => {
+        const docs = makeReports(count);
+
+        await docWriter.write(docs);
+
+        expect(getChtUrlStub.notCalled).to.be.true;
+        expect(postStub.notCalled).to.be.true;
+        expect(consoleErrorStub.notCalled).to.be.true;
+        expect(consoleInfoStub.notCalled).to.be.true;
+      });
+    });
+
+    it('logs error message when POST throws error', async () => {
+      const docs = makeReports(1000);
+      const dbName = 'medic';
+      postStub.rejects('Error message');
+
+      await docWriter.write(docs);
+
+      expect(getChtUrlStub.calledOnceWithExactly()).to.be.true;
+      expect(postStub.calledOnceWithExactly(`${BASE_URL}/${dbName}/${BULK_DOCS_PATH}`, { docs })).to.be.true;
+      expect(consoleErrorStub.calledOnce).to.be.true;
+      expect(consoleErrorStub.args[0][0]).to.equal(`Failed writing docs to ${dbName}. Errors: `);
+      expect(consoleErrorStub.args[0][1].name).to.deep.equal(`Error message`);
+      expect(consoleInfoStub.notCalled).to.be.true;
+    });
+  });
+
+  describe('flush', () => {
+    it('POSTs remaining docs in all databases', async () => {
+      const medicDocs = makeReports(999);
+      const sentinelDocs = makeReports(333);
+      const usersDocs = makeReports(1);
+
+      await docWriter.write(medicDocs);
+      await docWriter.write(sentinelDocs, 'sentinel');
+      await docWriter.write(usersDocs, '_users');
+
+      expect(postStub.notCalled).to.be.true;
+
+      await docWriter.flush();
+
+      expect(getChtUrlStub.callCount).to.equal(3);
+      expect(postStub.args).to.deep.equal([
+        [`${BASE_URL}/medic/${BULK_DOCS_PATH}`, { docs: medicDocs }],
+        [`${BASE_URL}/sentinel/${BULK_DOCS_PATH}`, { docs: sentinelDocs }],
+        [`${BASE_URL}/_users/${BULK_DOCS_PATH}`, { docs: usersDocs }],
+      ]);
+      expect(consoleErrorStub.notCalled).to.be.true;
+      expect(consoleInfoStub.args).to.deep.equal([
+        [getPostSuccessMsg(medicDocs.length, 'medic')],
+        [getPostSuccessMsg(sentinelDocs.length, 'sentinel')],
+        [getPostSuccessMsg(usersDocs.length, '_users')]
+      ]);
+    });
+
+    it('does nothing if no docs are queued for POSTing', async () => {
+      await docWriter.flush();
+
+      expect(getChtUrlStub.notCalled).to.be.true;
+      expect(postStub.notCalled).to.be.true;
+      expect(consoleErrorStub.notCalled).to.be.true;
+      expect(consoleInfoStub.notCalled).to.be.true;
+    });
+  });
+});

--- a/tests/docs.spec.ts
+++ b/tests/docs.spec.ts
@@ -1,19 +1,17 @@
-import axios from 'axios';
 import { assert, expect } from 'chai';
-import { stub, restore, resetHistory } from 'sinon';
+import { resetHistory, restore, stub } from 'sinon';
 
 import { Docs } from '../src/docs.js';
 import { DocType } from '../src/doc-design.js';
-import { environment } from '../src/environment.js';
+import docWriter from '../src/doc-writer.js';
 
 describe('Docs', () => {
-  let axiosPostStub;
-  let consoleErrorStub;
+  let writeStub;
+  let flushStub;
 
   beforeEach(() => {
-    stub(environment, 'getChtUrl').returns('http://localhost:5988');
-    axiosPostStub = stub(axios, 'post').resolves();
-    consoleErrorStub = stub(console, 'error');
+    writeStub = stub(docWriter, 'write').resolves();
+    flushStub = stub(docWriter, 'flush').resolves();
   });
 
   afterEach(() => restore());
@@ -73,66 +71,43 @@ describe('Docs', () => {
     await Docs.createDocs(designs)
       .catch(() => assert.fail('Should have not thrown error.'));
 
-    expect(axiosPostStub.callCount).to.equal(12);
-    expect(axiosPostStub.args[0][0]).to.contain('/medic-users-meta/_bulk_docs');
-    axiosPostStub.args.slice(1).forEach(call => expect(call[0]).to.contain('/medic/_bulk_docs'));
-    expect(axiosPostStub.args[0][1]).to.deep.equal({
-      docs: Array(2).fill({ ...reportDoc }),
-    });
-    expect(axiosPostStub.args[1][1]).to.deep.equal({
-      docs: [{ ...hospitalDoc }],
-    });
-    expect(axiosPostStub.args[2][1]).to.deep.equal({
-      docs: [{ ...unitDoc, parent: { _id: hospitalDoc._id } }],
-    });
-    expect(axiosPostStub.args[3][1]).to.deep.equal({
-      docs: Array(3).fill({
-        ...clinicDoc,
-        parent: { _id: unitDoc._id, parent: { _id: hospitalDoc._id } },
-      }),
-    });
-    expect(axiosPostStub.args[4][1]).to.deep.equal({
-      docs: Array(3).fill({
-        ...personDoc,
-        parent: { _id: unitDoc._id, parent: { _id: hospitalDoc._id } },
-      }),
-    });
-    expect(axiosPostStub.args[5][1]).to.deep.equal({
-      docs: [{
-        ...houseDoc,
-        parent: { _id: unitDoc._id, parent: { _id: hospitalDoc._id } },
-      }],
-    });
-    expect(axiosPostStub.args[6][1]).to.deep.equal({
-      docs: Array(2).fill({
-        ...personDoc,
-        parent: { _id: houseDoc._id, parent: { _id: unitDoc._id, parent: { _id: hospitalDoc._id } } },
-      }),
-    });
-    expect(axiosPostStub.args[7][1]).to.deep.equal({
-      docs: [{ ...centerDoc, parent: { _id: hospitalDoc._id } }],
-    });
-    expect(axiosPostStub.args[8][1]).to.deep.equal({
-      docs: Array(3).fill({
-        ...personDoc,
-        parent: { _id: centerDoc._id, parent: { _id: hospitalDoc._id } },
-      }),
-    });
-    expect(axiosPostStub.args[9][1]).to.deep.equal({
-      docs: [{
-        ...houseDoc,
-        parent: { _id: centerDoc._id, parent: { _id: hospitalDoc._id } },
-      }],
-    });
-    expect(axiosPostStub.args[10][1]).to.deep.equal({
-      docs: Array(10).fill({
-        ...personDoc,
-        parent: { _id: houseDoc._id, parent: { _id: centerDoc._id, parent: { _id: hospitalDoc._id } } },
-      }),
-    });
-    expect(axiosPostStub.args[11][1]).to.deep.equal({
-      docs: [{ ...personDoc, parent: { _id: hospitalDoc._id } }],
-    });
+    expect(writeStub.callCount).to.equal(12);
+    expect(writeStub.args[0][1]).to.equal('medic-users-meta');
+    writeStub.args.slice(1).forEach(([, dbName]) => expect(dbName).to.be.undefined);
+    expect(writeStub.args[0][0]).to.deep.equal(Array(2).fill({ ...reportDoc }));
+    expect(writeStub.args[1][0]).to.deep.equal([{ ...hospitalDoc }]);
+    expect(writeStub.args[2][0]).to.deep.equal([{ ...unitDoc, parent: { _id: hospitalDoc._id } }]);
+    expect(writeStub.args[3][0]).to.deep.equal(Array(3).fill({
+      ...clinicDoc,
+      parent: { _id: unitDoc._id, parent: { _id: hospitalDoc._id } },
+    }));
+    expect(writeStub.args[4][0]).to.deep.equal(Array(3).fill({
+      ...personDoc,
+      parent: { _id: unitDoc._id, parent: { _id: hospitalDoc._id } },
+    }));
+    expect(writeStub.args[5][0]).to.deep.equal([{
+      ...houseDoc,
+      parent: { _id: unitDoc._id, parent: { _id: hospitalDoc._id } },
+    }]);
+    expect(writeStub.args[6][0]).to.deep.equal(Array(2).fill({
+      ...personDoc,
+      parent: { _id: houseDoc._id, parent: { _id: unitDoc._id, parent: { _id: hospitalDoc._id } } },
+    }));
+    expect(writeStub.args[7][0]).to.deep.equal([{ ...centerDoc, parent: { _id: hospitalDoc._id } }]);
+    expect(writeStub.args[8][0]).to.deep.equal(Array(3).fill({
+      ...personDoc,
+      parent: { _id: centerDoc._id, parent: { _id: hospitalDoc._id } },
+    }));
+    expect(writeStub.args[9][0]).to.deep.equal([{
+      ...houseDoc,
+      parent: { _id: centerDoc._id, parent: { _id: hospitalDoc._id } },
+    }]);
+    expect(writeStub.args[10][0]).to.deep.equal(Array(10).fill({
+      ...personDoc,
+      parent: { _id: houseDoc._id, parent: { _id: centerDoc._id, parent: { _id: hospitalDoc._id } } },
+    }));
+    expect(writeStub.args[11][0]).to.deep.equal([{ ...personDoc, parent: { _id: hospitalDoc._id } }]);
+    expect(flushStub.calledOnceWithExactly()).to.be.true;
   });
 
   it('should create docs based on the doc design and not override parent object', async () => {
@@ -167,29 +142,22 @@ describe('Docs', () => {
     await Docs.createDocs(designs)
       .catch(() => assert.fail('Should have not thrown error.'));
 
-    expect(axiosPostStub.callCount).to.equal(7);
-    axiosPostStub.args.forEach(call => expect(call[0]).to.contain('/_bulk_docs'));
-    expect(axiosPostStub.args[0][1]).to.deep.equal({
-      docs: [{ ...hospitalDoc }],
-    });
-    expect(axiosPostStub.args[1][1]).to.deep.equal({
-      docs: Array(4).fill({ ...unitDoc, parent: { _id: hospitalDoc._id } }),
-    });
-    expect(axiosPostStub.args[2][1]).to.deep.equal({
-      docs: Array(13).fill({ ...centerDoc, parent: { _id: '009' } }),
-    });
-    expect(axiosPostStub.args[3][1]).to.deep.equal({
-      docs: Array(3).fill({ ...centerDoc, parent: { _id: '007' } }),
-    });
-    expect(axiosPostStub.args[4][1]).to.deep.equal({
-      docs: Array(7).fill({ ...unitDoc, parent: { _id: centerDoc._id, parent: { _id: '007' } } }),
-    });
-    expect(axiosPostStub.args[5][1]).to.deep.equal({
-      docs: Array(7).fill({ ...unitDoc, parent: { _id: centerDoc._id, parent: { _id: '007' } } }),
-    });
-    expect(axiosPostStub.args[6][1]).to.deep.equal({
-      docs: Array(7).fill({ ...unitDoc, parent: { _id: centerDoc._id, parent: { _id: '007' } } }),
-    });
+    expect(writeStub.callCount).to.equal(7);
+    writeStub.args.forEach(([,dbName]) => expect(dbName).to.be.undefined);
+    expect(writeStub.args[0][0]).to.deep.equal([{ ...hospitalDoc }]);
+    expect(writeStub.args[1][0]).to.deep.equal(Array(4).fill({ ...unitDoc, parent: { _id: hospitalDoc._id } }));
+    expect(writeStub.args[2][0]).to.deep.equal(Array(13).fill({ ...centerDoc, parent: { _id: '009' } }));
+    expect(writeStub.args[3][0]).to.deep.equal(Array(3).fill({ ...centerDoc, parent: { _id: '007' } }));
+    expect(writeStub.args[4][0]).to.deep.equal(
+      Array(7).fill({ ...unitDoc, parent: { _id: centerDoc._id, parent: { _id: '007' } } }),
+    );
+    expect(writeStub.args[5][0]).to.deep.equal(
+      Array(7).fill({ ...unitDoc, parent: { _id: centerDoc._id, parent: { _id: '007' } } }),
+    );
+    expect(writeStub.args[6][0]).to.deep.equal(
+      Array(7).fill({ ...unitDoc, parent: { _id: centerDoc._id, parent: { _id: '007' } } }),
+    );
+    expect(flushStub.calledOnceWithExactly()).to.be.true;
   });
 
   it('should provide the parent doc value when getting a new doc from the design', async () => {
@@ -208,11 +176,12 @@ describe('Docs', () => {
     await Docs.createDocs(designs)
       .catch(() => assert('Should have not thrown error.'));
 
-    expect(axiosPostStub.callCount).to.equal(2);
+    expect(writeStub.callCount).to.equal(2);
     expect(getHospitalDoc.calledOnce).to.be.true;
     expect(getHospitalDoc.args[0][0]).to.deep.equal({ parent: undefined });
     expect(getCenterDoc.calledOnce).to.be.true;
     expect(getCenterDoc.args[0][0]).to.deep.equal({ parent: hospitalDoc });
+    expect(flushStub.calledOnceWithExactly()).to.be.true;
   });
 
   it('should generate _id value if none is provided', async () => {
@@ -222,10 +191,11 @@ describe('Docs', () => {
     await Docs.createDocs(designs)
       .catch(() => assert.fail('Should have not thrown error.'));
 
-    expect(axiosPostStub.callCount).to.equal(1);
-    const actualDoc = axiosPostStub.args[0][1].docs[0];
+    expect(writeStub.callCount).to.equal(1);
+    const actualDoc = writeStub.args[0][0][0];
     expect(actualDoc).to.deep.include(hospitalDoc);
     expect(actualDoc._id).to.be.a('string');
+    expect(flushStub.calledOnceWithExactly()).to.be.true;
   });
 
   it('should auto-populate parent linkage fields when writing new contacts', async () => {
@@ -254,20 +224,21 @@ describe('Docs', () => {
     await Docs.createDocs(designs)
       .catch(() => assert.fail('Should have not thrown error.'));
 
-    expect(axiosPostStub.callCount).to.equal(4);
-    expect(axiosPostStub.args[0][1]).to.deep.equal({ docs: [greatGrandParent] });
-    expect(axiosPostStub.args[1][1]).to.deep.equal({ docs: [{
+    expect(writeStub.callCount).to.equal(4);
+    expect(writeStub.args[0][0]).to.deep.equal([greatGrandParent]);
+    expect(writeStub.args[1][0]).to.deep.equal([{
       ...grandParent,
       parent: { _id: greatGrandParent._id }
-    }] });
-    expect(axiosPostStub.args[2][1]).to.deep.equal({ docs: [{
+    }]);
+    expect(writeStub.args[2][0]).to.deep.equal([{
       ...parent,
       parent: { _id: grandParent._id, parent: { _id: greatGrandParent._id } }
-    }] });
-    expect(axiosPostStub.args[3][1]).to.deep.equal({ docs: [{
+    }]);
+    expect(writeStub.args[3][0]).to.deep.equal([{
       ...doc,
       parent: { _id: parent._id, parent: { _id: grandParent._id, parent: { _id: greatGrandParent._id } } }
-    }] });
+    }]);
+    expect(flushStub.calledOnceWithExactly()).to.be.true;
   });
 
   it('should use provided data to populate contact parent linkage fields', async () => {
@@ -283,9 +254,10 @@ describe('Docs', () => {
     await Docs.createDocs(designs)
       .catch(() => assert.fail('Should have not thrown error.'));
 
-    expect(axiosPostStub.callCount).to.equal(2);
-    expect(axiosPostStub.args[0][1]).to.deep.equal({ docs: [parent] });
-    expect(axiosPostStub.args[1][1]).to.deep.equal({ docs: [doc] });
+    expect(writeStub.callCount).to.equal(2);
+    expect(writeStub.args[0][0]).to.deep.equal([parent]);
+    expect(writeStub.args[1][0]).to.deep.equal([doc]);
+    expect(flushStub.calledOnceWithExactly()).to.be.true;
   });
 
   [
@@ -311,16 +283,17 @@ describe('Docs', () => {
       await Docs.createDocs(designs)
         .catch(() => assert.fail('Should have not thrown error.'));
 
-      expect(axiosPostStub.callCount).to.equal(2);
-      expect(axiosPostStub.args[0][1]).to.deep.equal({ docs: [parent] });
-      expect(axiosPostStub.args[1][1]).to.deep.equal({ docs: [{
+      expect(writeStub.callCount).to.equal(2);
+      expect(writeStub.args[0][0]).to.deep.equal([parent]);
+      expect(writeStub.args[1][0]).to.deep.equal([{
         ...doc,
         contact: { _id: parent._id },
         fields: {
           ...doc.fields,
           ...expectedFields
         }
-      }] });
+      }]);
+      expect(flushStub.calledOnceWithExactly()).to.be.true;
     });
   });
 
@@ -359,50 +332,7 @@ describe('Docs', () => {
     await Docs.createDocs(designs)
       .then(() => assert.fail('Should have thrown error.'))
       .catch(error => expect(error.message).to.equal('Remember to set the "amount" and the "getDoc" in design-1.'));
-  });
 
-  it('should catch errors when saving docs', async () => {
-    const designs = [
-      { designId: 'design-1', amount: 2, getDoc: () => ({ _id: '124', type: 'hospital' }) },
-    ];
-    const error = new Error('Ups something happened');
-    axiosPostStub.rejects(error);
-
-    await Docs.createDocs(designs);
-
-    expect(axiosPostStub.calledOnce).to.be.true;
-    expect(consoleErrorStub.calledOnce).to.be.true;
-    expect(consoleErrorStub.args[0]).to.have.members([ 'Failed saving docs from design-1. Errors: ', error.message ]);
-  });
-
-  it('should catch errors when saving docs, but continue saving other batches', async () => {
-    const designs = [
-      {
-        designId: 'design-1',
-        amount: 2,
-        getDoc: () => ({ _id: '124', type: 'ward-b' })
-      },
-      {
-        designId: 'design-2',
-        amount: 2,
-        getDoc: () => ({ _id: '888', type: 'ward-a' })
-      },
-    ];
-    const error = new Error('Ups something happened');
-    axiosPostStub.onFirstCall().rejects(error);
-
-    await Docs.createDocs(designs);
-
-    expect(axiosPostStub.calledTwice).to.be.true;
-    expect(axiosPostStub.args[0][0]).to.contain('/_bulk_docs');
-    expect(axiosPostStub.args[0][1]).to.deep.equal({
-      docs: Array(2).fill({ _id: '124', type: 'ward-b' }),
-    });
-    expect(axiosPostStub.args[1][0]).to.contain('/_bulk_docs');
-    expect(axiosPostStub.args[1][1]).to.deep.equal({
-      docs: Array(2).fill({ _id: '888', type: 'ward-a' }),
-    });
-    expect(consoleErrorStub.calledOnce).to.be.true;
-    expect(consoleErrorStub.args[0]).to.have.members([ 'Failed saving docs from design-1. Errors: ', error.message ]);
+    expect(flushStub.notCalled).to.be.true;
   });
 });


### PR DESCRIPTION
Closes https://github.com/medic/test-data-generator/issues/21

I did some testing locally to try and profile the performance here.  Firstly, running locally on my laptop (with 32GB of RAM and 12 CPU threads), pushing any large amount of data  (20,000+ docs) into `medic` would quickly bottleneck on view indexing, maxing out the CPU, _regardless of how the doc writes were batched_. This bottlenecking affects the test-data-generator runs because it seems like Couch's ability to process new `_bulk_docs` requests is severely impacted by having a bunch of indexing jobs already running. Eventually the TDG process starts to hang on the POST calls to `_bulk_docs` because Couch is not responding.  I suspect it may just be a matter of thread-pool exhaustion.  Whatever the case, the changes in this PR are unlikely to significantly improve observed write speeds to _local CouchDB instances_.  Writing (even smaller amounts of data) to remote CouchDb instances will be faster, though, since this change does optimize the network requests.  

To get a better idea of raw data write speeds, I also tested against an empty CouchDB (with no views).  This way I was able to better measure the data throughput without bottlenecking on the view indexing.  Against this empty database I did a very unscientific comparison of TDG runtime for writing 200,000 docs (from a non-trivial hierarchical design) with different batch sizes:

| Batch Size | Runtime |
| --- | --- |
| `master` | 67sec |
| 500 | 37sec |
| 1000 | 32sec |
| 2000 | 32sec |
| 5000 | 34sec |

I ended up settling on a batch size of `1000` docs. It is a nice round number, and anything higher did not provide any clear benefit.  