### PR TITLE
chore: add support for passing url as cli parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,18 +26,20 @@ Design the test data that fit your project hierarchy and reports. The tool will 
 
 Instructions on setting up the project and getting it running on a local machine.
 
-- Set the `COUCH_URL` environment variable to point your test instance, for example it is something similar to this: `http://[user]:[pass]@[host]:[port]/medic`
 - Double-check your CHT test instance is running
 - Clone or fork the test data generator repository
 - Install and build the project by running `npm ci` in the project root folder
 - Design the test data in a custom JavaScript file. See the section [Designing Test Data](#designing-test-data).
-- Build, generate data, and upload by running `npm run generate *path_to_your_custom_design_file*`
+- Set your target instance CHT_URL:
+  - Either set the `COUCH_URL` environment variable to point your test instance, for example it is something similar to this: `http://[user]:[pass]@[host]:[port]/medic`
+  - Pass it as a parameter to the `generate` script
+- Build, generate data, and upload by running `npm run generate <path_to_your_custom_design_file> <*CHT_URL*>`
 
 ### Install it globally
 Another option is to install the tool globally:
 - Install package dependencies and build the project `npm ci`
 - Run `npm install -g` in the project root folder
-- Build, generate, and upload data by running `tdg <path_to_your_custom_design_file>`.
+- Build, generate, and upload data by running `tdg <path_to_your_custom_design_file> <*CHT_URL*>`.
 
 ### Use it with Docker
 The tool is also available in Docker:

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,17 +1,21 @@
 import { resolve, extname } from 'node:path';
 import { existsSync } from 'node:fs';
 
-const SUPPORTED_INPUT_FILE = '.js';
+const args = () => process.argv.slice(2);
 
+const getChtUrl = () => {
+  return args()[1] || process.env.COUCH_URL;
+};
+
+const SUPPORTED_INPUT_FILE = '.js';
 const getInputFilePath = () => {
-  const args = process.argv.slice(2);
-  if (!args?.length) {
+  if (!args()?.length) {
     throw new Error(
       'No path to the design file provided.'
     );
   }
 
-  const path = resolve(args[0]);
+  const path = resolve(args()[0]);
   if (extname(path) !== SUPPORTED_INPUT_FILE) {
     throw new Error(
       'The design file is not a JavaScript file. Retry using a file with extension ending in .js'
@@ -27,4 +31,5 @@ const getInputFilePath = () => {
 
 export const cli = {
   getInputFilePath,
+  getChtUrl,
 };

--- a/src/environment.ts
+++ b/src/environment.ts
@@ -1,3 +1,5 @@
+import { cli } from './cli.js';
+
 let url: URL;
 let auth: string;
 let username: string;
@@ -7,24 +9,25 @@ const getChtUrl = () => {
     return url.toString();
   }
 
-  if (!process.env.COUCH_URL) {
+  const chtUrl = cli.getChtUrl();
+  if (!chtUrl) {
     throw new Error('COUCH_URL environment variable must be set.');
   }
 
-  const match = /(https?:\/\/[^/]+)/i.exec(process.env.COUCH_URL);
+  const match = /(https?:\/\/[^/]+)/i.exec(chtUrl);
   if (!match) {
-    throw new Error(`Failed to parse COUCH_URL [${process.env.COUCH_URL}].`);
+    throw new Error(`Failed to parse COUCH_URL [${chtUrl}].`);
   }
 
   try {
-    url = new URL(process.env.COUCH_URL);
+    url = new URL(chtUrl);
     auth = Buffer.from(`${url.username}:${url.password}`, 'utf8').toString('base64');
     username = url.username;
     url.username = '';
     url.password = '';
     url.pathname = '';
   } catch (err) {
-    throw new Error(`Failed to parse COUCH_URL [${process.env.COUCH_URL}].`);
+    throw new Error(`Failed to parse COUCH_URL [${chtUrl}].`);
   }
 
   return url.toString();
@@ -39,7 +42,7 @@ const getUsername = () => {
   getChtUrl();
 
   if (!username) {
-    console.error(`Failed to parse username from COUCH_URL [${process.env.COUCH_URL}].`);
+    console.error(`Failed to parse username from COUCH_URL [${url.toString()}].`);
   }
   return username;
 };

--- a/tests/cli.spec.ts
+++ b/tests/cli.spec.ts
@@ -1,29 +1,24 @@
 import { resolve } from 'node:path';
 import { expect, assert } from 'chai';
-import * as Sinon from 'sinon';
-import { restore, stub } from 'sinon';
+import * as sinon from 'sinon';
 import { cli } from '../src/cli.js';
 
 describe('cli', () => {
-  let argvStub: Sinon.SinonStub;
+  let argvStub: sinon.SinonStub;
+  let envStub: sinon.SinonStub;
 
   beforeEach(() => {
-    argvStub = stub(process, 'argv');
+    argvStub = sinon.stub(process, 'argv');
+    envStub = sinon.stub(process, 'env');
   });
 
-  afterEach(() => restore());
+  afterEach(() => sinon.restore());
 
   describe('getInputFilePath', () => {
     it('should return the design file path successfully', () => {
-      try {
-        argvStub.get(() => [ 'node-path', 'application-entry', 'tests/files/empty-design-file.js' ]);
-
-        const path = cli.getInputFilePath();
-
-        expect(path).to.equal(resolve('tests/files/empty-design-file.js'));
-      } catch (error) {
-        assert.fail('Should have not thrown an error');
-      }
+      argvStub.get(() => [ 'node-path', 'application-entry', 'tests/files/empty-design-file.js' ]);
+      const path = cli.getInputFilePath();
+      expect(path).to.equal(resolve('tests/files/empty-design-file.js'));
     });
 
     it('should throw an error when design file does not exist in path', () => {
@@ -72,6 +67,21 @@ describe('cli', () => {
           'No path to the design file provided.'
         );
       }
+    });
+  });
+
+  describe('getChtUrl', () => {
+    it('should return the URL param when provided', () => {
+      argvStub.get(() => [ 'node-path', 'application-entry', 'tests/files/empty-design-file.js', 'http://localhost:5984' ]);
+      const url = cli.getChtUrl();
+      expect(url).to.equal('http://localhost:5984');
+    });
+
+    it('should return env COUCH_URL no URL param is provided', () => {
+      argvStub.get(() => [ 'node-path', 'application-entry', 'tests/files/empty-design-file.js' ]);
+      envStub.get(() => ({ COUCH_URL: 'https://localhost' }));
+      const url = cli.getChtUrl();
+      expect(url).to.equal('https://localhost');
     });
   });
 });

--- a/tests/environment.spec.ts
+++ b/tests/environment.spec.ts
@@ -1,20 +1,16 @@
 import { expect } from 'chai';
-import * as Sinon from 'sinon';
-import { restore, stub } from 'sinon';
+import * as sinon from 'sinon';
+import { cli } from '../src/cli.js';
 
 describe('environment', () => {
-  let couchURL: string;
-  let consoleErrorStub: Sinon.SinonStub;
+  let consoleErrorStub: sinon.SinonStub;
 
-  before(() => couchURL = process.env.COUCH_URL);
-  after(() => process.env.COUCH_URL = couchURL);
-
-  beforeEach(() => consoleErrorStub = stub(console, 'error'));
-  afterEach(() => restore());
+  beforeEach(() => consoleErrorStub = sinon.stub(console, 'error'));
+  afterEach(() => sinon.restore());
 
   describe('getChtUrl', () => {
     it('should throw an error when COUCH_URL is not set', async () => {
-      process.env.COUCH_URL = '';
+      sinon.stub(cli, 'getChtUrl').returns('');
       const { environment } = await import(`../src/environment.ts?${Date.now()}`);
       expect(environment.getChtUrl).to.throw('COUCH_URL environment variable must be set.');
     });
@@ -26,9 +22,8 @@ describe('environment', () => {
       'http:///admin:password@localhost:5984'
     ].forEach(couchURL => {
       it('should throw an error when COUCH_URL does not match the expected format', async () => {
-        process.env.COUCH_URL = couchURL;
+        sinon.stub(cli, 'getChtUrl').returns(couchURL);
         const { environment } = await import(`../src/environment.ts?${Date.now()}`);
-        console.warn(couchURL);
         expect(environment.getChtUrl).to.throw(`Failed to parse COUCH_URL [${couchURL}].`);
       });
     });
@@ -40,7 +35,7 @@ describe('environment', () => {
       ['https://root:root@google.com/somewhere/else', 'https://google.com/'],
     ].forEach(([couchURL, expected]) => {
       it('should return the base URL when COUCH_URL is valid', async () => {
-        process.env.COUCH_URL = couchURL;
+        sinon.stub(cli, 'getChtUrl').returns(couchURL);
         const { environment } = await import(`../src/environment.ts?${Date.now()}`);
         const result = environment.getChtUrl();
         expect(result).to.equal(expected);
@@ -54,7 +49,7 @@ describe('environment', () => {
       'https://admin:password@localhost:5984',
     ].forEach(couchURL => {
       it(`should include username from COUCH_URL (${couchURL})`, async () => {
-        process.env.COUCH_URL = couchURL;
+        sinon.stub(cli, 'getChtUrl').returns(couchURL);
         const { environment } = await import(`../src/environment.ts?${Date.now()}`);
         const context = environment.getUsername();
         expect(context).to.equal('admin');
@@ -62,14 +57,14 @@ describe('environment', () => {
     });
 
     it('should include null username when not included in COUCH_URL', async () => {
-      process.env.COUCH_URL = 'http://localhost:5984';
+      sinon.stub(cli, 'getChtUrl').returns('http://localhost:5984');
       const { environment } = await import(`../src/environment.ts?${Date.now()}`);
 
       const username = environment.getUsername();
       expect(username).to.equal('');
       expect(consoleErrorStub.calledOnce).to.be.true;
       expect(consoleErrorStub.args[0]).to.deep
-        .equal([`Failed to parse username from COUCH_URL [http://localhost:5984].`]);
+        .equal([`Failed to parse username from COUCH_URL [http://localhost:5984/].`]);
     });
   });
 
@@ -79,7 +74,7 @@ describe('environment', () => {
       ['https://root:root@google.com/', 'cm9vdDpyb290'],
     ].forEach(([couchURL, expected]) => {
       it('should return the correct auth when COUCH_URL is valid', async () => {
-        process.env.COUCH_URL = couchURL;
+        sinon.stub(cli, 'getChtUrl').returns(couchURL);
         const { environment } = await import(`../src/environment.ts?${Date.now()}`);
         const result = environment.getAuth();
         expect(result).to.equal(expected);


### PR DESCRIPTION
COUCH_URL is overused in our projects. FWIW the parameter that tgd should use would be more suitably called CHT_URL or CHT_API_URL, because it's not Couch we're targeting.   