### PR TITLE
feat(#32): add option to save reports as JSON files for workflow testing

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -3,19 +3,62 @@ import { existsSync } from 'node:fs';
 
 const args = () => process.argv.slice(2);
 
+const getFlag = (flag: string): string | undefined => {
+  const flagIndex = args().indexOf(flag);
+  if (flagIndex !== -1 && args()[flagIndex + 1]) {
+    return args()[flagIndex + 1];
+  }
+  return undefined;
+};
+
 const getChtUrl = () => {
-  return args()[1] || process.env.COUCH_URL;
+  const flagUrl = getFlag('--couch-url');
+  if (flagUrl) {
+    return flagUrl;
+  }
+  
+  if (process.env.COUCH_URL) {
+    return process.env.COUCH_URL;
+  }
+  
+  if (args()[1] && !args()[1].startsWith('--')) {
+    return args()[1];
+  }
+  
+  return undefined;
+};
+
+const getSaveReportsDir = (): string | undefined => {
+  return getFlag('--save-reports-json');
+};
+
+const getSaveReportsPercentage = (): number => {
+  const percentage = getFlag('--save-reports-percentage');
+  if (!percentage) {
+    return 100;
+  }
+  const value = parseInt(percentage, 10);
+  if (isNaN(value) || value < 0 || value > 100) {
+    throw new Error('--save-reports-percentage must be between 0 and 100');
+  }
+  return value;
 };
 
 const SUPPORTED_INPUT_FILE = '.js';
 const getInputFilePath = () => {
-  if (!args()?.length) {
+  const designFileArg = args().find((arg, idx) => {
+    if (arg.startsWith('--')) return false;
+    if (idx > 0 && args()[idx - 1].startsWith('--')) return false;
+    return true;
+  });
+  
+  if (!designFileArg) {
     throw new Error(
       'No path to the design file provided.'
     );
   }
 
-  const path = resolve(args()[0]);
+  const path = resolve(designFileArg);
   if (extname(path) !== SUPPORTED_INPUT_FILE) {
     throw new Error(
       'The design file is not a JavaScript file. Retry using a file with extension ending in .js'
@@ -32,4 +75,6 @@ const getInputFilePath = () => {
 export const cli = {
   getInputFilePath,
   getChtUrl,
+  getSaveReportsDir,
+  getSaveReportsPercentage,
 };

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -5,12 +5,8 @@ const args = () => process.argv.slice(2);
 
 const getFlag = (flag: string): string | undefined => {
   const flagIndex = args().indexOf(flag);
-  if (flagIndex !== -1 && args()[flagIndex + 1]) {
-    return args()[flagIndex + 1];
-  }
-  return undefined;
+  return flagIndex !== -1 ? args()[flagIndex + 1] : undefined;
 };
-
 const getChtUrl = () => {
   const flagUrl = getFlag('--couch-url');
   if (flagUrl) {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -47,8 +47,12 @@ const getSaveReportsPercentage = (): number => {
 const SUPPORTED_INPUT_FILE = '.js';
 const getInputFilePath = () => {
   const designFileArg = args().find((arg, idx) => {
-    if (arg.startsWith('--')) return false;
-    if (idx > 0 && args()[idx - 1].startsWith('--')) return false;
+    if (arg.startsWith('--')){
+      return false;
+    }
+    if (idx > 0 && args()[idx - 1].startsWith('--')){
+      return false;
+    }
     return true;
   });
   

--- a/src/docs.ts
+++ b/src/docs.ts
@@ -1,16 +1,45 @@
 import { v4 as uuid } from 'uuid';
 import { Doc, DocType, Parent } from './doc-design.js';
 import docWriter from './doc-writer.js';
+import ReportsSaver from './reports-saver.js';
 
 export class Docs {
+  private static reportsSaver: ReportsSaver | null = null;
+
+  static setReportsSaver(saver: ReportsSaver) {
+    Docs.reportsSaver = saver;
+  }
+
   private static async saveDocs(docs, dbName, batchId) {
-    console.info(`Saving ${docs.length} docs for ${batchId}...`);
-    return docWriter.write(docs, dbName);
+    let docsToUpload = docs;
+    
+    if (Docs.reportsSaver) {
+      const savedReports = await Docs.reportsSaver.saveReports(docs);
+      const savedIds = new Set(savedReports.map(r => r._id));
+      docsToUpload = docs.filter(doc => !savedIds.has(doc._id));
+      
+      if (docsToUpload.length < docs.length) {
+        console.info(`Saving ${docsToUpload.length} docs for ${batchId} (${docs.length - docsToUpload.length} reports saved to JSON, will not upload)...`);
+      } else {
+        console.info(`Saving ${docsToUpload.length} docs for ${batchId}...`);
+      }
+    } else {
+      console.info(`Saving ${docs.length} docs for ${batchId}...`);
+    }
+    
+    if (docsToUpload.length > 0) {
+      return docWriter.write(docsToUpload, dbName);
+    }
   }
 
   static async createDocs(designs, parentDoc?: Doc) {
     await Docs.createDocsForDesigns(designs, parentDoc);
-    !parentDoc && await docWriter.flush();
+    if (!parentDoc) {
+      await docWriter.flush();
+      if (Docs.reportsSaver) {
+        await Docs.reportsSaver.flush();
+      }
+    }
   }
 
   private static async createDocsForDesigns(designs, parentDoc?: Doc) {

--- a/src/docs.ts
+++ b/src/docs.ts
@@ -4,7 +4,7 @@ import docWriter from './doc-writer.js';
 import ReportsSaver from './reports-saver.js';
 
 export class Docs {
-  private static reportsSaver: ReportsSaver | null = null;
+  private static reportsSaver?: ReportsSaver;
 
   static setReportsSaver(saver: ReportsSaver) {
     Docs.reportsSaver = saver;
@@ -17,15 +17,7 @@ export class Docs {
       const savedReports = await Docs.reportsSaver.saveReports(docs);
       const savedIds = new Set(savedReports.map(r => r._id));
       docsToUpload = docs.filter(doc => !savedIds.has(doc._id));
-      
-      if (docsToUpload.length < docs.length) {
-        console.info(`Saving ${docsToUpload.length} docs for ${batchId} (${docs.length - docsToUpload.length} reports saved to JSON, will not upload)...`);
-      } else {
-        console.info(`Saving ${docsToUpload.length} docs for ${batchId}...`);
-      }
-    } else {
-      console.info(`Saving ${docs.length} docs for ${batchId}...`);
-    }
+    } 
     
     if (docsToUpload.length > 0) {
       return docWriter.write(docsToUpload, dbName);

--- a/src/docs.ts
+++ b/src/docs.ts
@@ -10,7 +10,7 @@ export class Docs {
     Docs.reportsSaver = saver;
   }
 
-  private static async saveDocs(docs: Doc[], dbName: string, batchId?: string) {
+  private static async saveDocs(docs: Doc[], dbName: string) {
     let docsToUpload = docs;
     
     if (Docs.reportsSaver) {
@@ -62,7 +62,7 @@ export class Docs {
         };
       });
 
-    await Docs.saveDocs(batch.map(entity => entity.doc), design.db, design.designId);
+    await Docs.saveDocs(batch.map(entity => entity.doc), design.db);
     const entityWithChildrenToCreate = batch
       .filter(entity => entity.doc.type !== DocType.dataRecord && entity.design.children);
     for(const entity of entityWithChildrenToCreate) {

--- a/src/docs.ts
+++ b/src/docs.ts
@@ -10,7 +10,7 @@ export class Docs {
     Docs.reportsSaver = saver;
   }
 
-  private static async saveDocs(docs, dbName, batchId) {
+  private static async saveDocs(docs: Doc[], dbName: string, batchId?: string) {
     let docsToUpload = docs;
     
     if (Docs.reportsSaver) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,12 +4,21 @@ import { cli } from './cli.js';
 import { Docs } from './docs.js';
 import { DocDesign } from './doc-design.js';
 import { context } from './design-context.js';
+import ReportsSaver from './reports-saver.js';
 
 process.env.NODE_TLS_REJECT_UNAUTHORIZED = String(0); // allow self-signed certificates
 
 (async function() {
   try {
     const designScriptPath = cli.getInputFilePath();
+    const saveReportsDir = cli.getSaveReportsDir();
+    const saveReportsPercentage = cli.getSaveReportsPercentage();
+    
+    if (saveReportsDir) {
+      const reportsSaver = new ReportsSaver(saveReportsDir, saveReportsPercentage);
+      Docs.setReportsSaver(reportsSaver);
+    }
+    
     const getDesign: DocDesign = (await import(designScriptPath)).default;
     await Docs.createDocs(getDesign(context.get()));
   } catch (error) {

--- a/src/reports-saver.ts
+++ b/src/reports-saver.ts
@@ -42,11 +42,12 @@ class ReportsSaver {
       let username = this.currentUser;
       
       if ('contact' in report && report.contact && typeof report.contact === 'object') {
-        const contact: any = report.contact;
+        type ContactHierarchy = { _id?: string; parent?: ContactHierarchy };
+        const contact = report.contact as ContactHierarchy;
         let current = contact;
         while (current && current.parent) {
           if (current.parent._id && this.facilityToUser.has(current.parent._id)) {
-            username = this.facilityToUser.get(current.parent._id)!;
+            username = this.facilityToUser.get(current.parent._id);
             break;
           }
           current = current.parent;

--- a/src/reports-saver.ts
+++ b/src/reports-saver.ts
@@ -1,0 +1,111 @@
+import { writeFile, mkdir } from 'node:fs/promises';
+import { existsSync } from 'node:fs';
+import { join } from 'node:path';
+import { Doc, DocType } from './doc-design.js';
+
+class ReportsSaver {
+  private saveDir: string | undefined;
+  private percentage: number;
+  private savedCount = 0;
+  private reportsByUser: Map<string, Doc[]> = new Map();
+  private facilityToUser: Map<string, string> = new Map(); // Maps facility_id to username
+  private currentUser: string | null = null;
+
+  constructor(saveDir: string | undefined, percentage: number) {
+    this.saveDir = saveDir;
+    this.percentage = percentage;
+  }
+
+  async saveReports(docs: Doc[]): Promise<Doc[]> {
+    if (!this.saveDir) {
+      return [];
+    }
+
+    // Track user-facility mapping (CHW creates user-settings with facility_id)
+    const userSettingsDoc = docs.find(doc => doc.type === 'user-settings');
+    if (userSettingsDoc && 'name' in userSettingsDoc && 'facility_id' in userSettingsDoc) {
+      const username = userSettingsDoc.name as string;
+      const facilityId = userSettingsDoc.facility_id as string;
+      this.facilityToUser.set(facilityId, username);
+      this.currentUser = username;
+    }
+    
+    const reports = docs.filter(doc => doc.type === DocType.dataRecord);    
+    if (reports.length === 0) {
+      return [];
+    }
+    const reportsToSave = reports.filter(() => Math.random() * 100 < this.percentage);    
+    if (reportsToSave.length === 0) {
+      return [];
+    }
+
+    // Assign reports to users based on facility hierarchy
+    for (const report of reportsToSave) {
+      let username = this.currentUser; // Default to current user
+      
+      // Try to find user from report's contact hierarchy
+      if ('contact' in report && report.contact && typeof report.contact === 'object') {
+        const contact: any = report.contact;
+        // Navigate up the hierarchy to find the clinic (which has the facility_id)
+        let current = contact;
+        while (current && current.parent) {
+          if (current.parent._id && this.facilityToUser.has(current.parent._id)) {
+            username = this.facilityToUser.get(current.parent._id)!;
+            break;
+          }
+          current = current.parent;
+        }
+      }
+      
+      if (username) {
+        if (!this.reportsByUser.has(username)) {
+          this.reportsByUser.set(username, []);
+        }
+        this.reportsByUser.get(username)!.push(report);
+      }
+    }
+
+    this.savedCount += reportsToSave.length;    
+    return reportsToSave;
+  }
+
+  async flush(): Promise<void> {
+    if (!this.saveDir || this.reportsByUser.size === 0) {
+      return;
+    }
+    if (!existsSync(this.saveDir)) {
+      await mkdir(this.saveDir, { recursive: true });
+    }
+
+    // Write individual user report files
+    for (const [username, reports] of this.reportsByUser.entries()) {
+      const outputPath = join(this.saveDir, `${username}-reports.json`);
+      await writeFile(outputPath, JSON.stringify(reports, null, 2));
+      console.info(`   👤 ${username}: ${reports.length} reports → ${outputPath}`);
+    }
+
+    // Write summary
+    const summary = {
+      total_reports: this.savedCount,
+      total_users: this.reportsByUser.size,
+      average_reports_per_user: Math.round(this.savedCount / this.reportsByUser.size),
+      percentage_saved: this.percentage,
+      generated_at: new Date().toISOString(),
+      users: Array.from(this.reportsByUser.entries()).map(([username, reports]) => ({
+        username,
+        report_count: reports.length
+      }))
+    };
+    
+    const summaryPath = join(this.saveDir, 'summary.json');
+    await writeFile(summaryPath, JSON.stringify(summary, null, 2));
+    
+    console.info(`\n📄 Saved ${this.savedCount} reports (${this.percentage}%) for ${this.reportsByUser.size} users`);
+    console.info(`   Average: ${summary.average_reports_per_user} reports per user`);
+    console.info(`   Output directory: ${this.saveDir}`);
+    console.info(`   Summary: ${summaryPath}`);
+  }
+}
+
+export default ReportsSaver;
+

--- a/src/reports-saver.ts
+++ b/src/reports-saver.ts
@@ -4,14 +4,14 @@ import { join } from 'node:path';
 import { Doc, DocType } from './doc-design.js';
 
 class ReportsSaver {
-  private saveDir: string | undefined;
+  private saveDir?: string;
   private percentage: number;
   private savedCount = 0;
   private reportsByUser: Map<string, Doc[]> = new Map();
-  private facilityToUser: Map<string, string> = new Map(); // Maps facility_id to username
-  private currentUser: string | null = null;
+  private facilityToUser: Map<string, string> = new Map();
+  private currentUser?: string;
 
-  constructor(saveDir: string | undefined, percentage: number) {
+  constructor(saveDir: string, percentage: number) {
     this.saveDir = saveDir;
     this.percentage = percentage;
   }
@@ -21,7 +21,6 @@ class ReportsSaver {
       return [];
     }
 
-    // Track user-facility mapping (CHW creates user-settings with facility_id)
     const userSettingsDoc = docs.find(doc => doc.type === 'user-settings');
     if (userSettingsDoc && 'name' in userSettingsDoc && 'facility_id' in userSettingsDoc) {
       const username = userSettingsDoc.name as string;
@@ -39,14 +38,11 @@ class ReportsSaver {
       return [];
     }
 
-    // Assign reports to users based on facility hierarchy
     for (const report of reportsToSave) {
-      let username = this.currentUser; // Default to current user
+      let username = this.currentUser;
       
-      // Try to find user from report's contact hierarchy
       if ('contact' in report && report.contact && typeof report.contact === 'object') {
         const contact: any = report.contact;
-        // Navigate up the hierarchy to find the clinic (which has the facility_id)
         let current = contact;
         while (current && current.parent) {
           if (current.parent._id && this.facilityToUser.has(current.parent._id)) {
@@ -77,14 +73,11 @@ class ReportsSaver {
       await mkdir(this.saveDir, { recursive: true });
     }
 
-    // Write individual user report files
     for (const [username, reports] of this.reportsByUser.entries()) {
       const outputPath = join(this.saveDir, `${username}-reports.json`);
       await writeFile(outputPath, JSON.stringify(reports, null, 2));
-      console.info(`   👤 ${username}: ${reports.length} reports → ${outputPath}`);
     }
 
-    // Write summary
     const summary = {
       total_reports: this.savedCount,
       total_users: this.reportsByUser.size,
@@ -99,11 +92,6 @@ class ReportsSaver {
     
     const summaryPath = join(this.saveDir, 'summary.json');
     await writeFile(summaryPath, JSON.stringify(summary, null, 2));
-    
-    console.info(`\n📄 Saved ${this.savedCount} reports (${this.percentage}%) for ${this.reportsByUser.size} users`);
-    console.info(`   Average: ${summary.average_reports_per_user} reports per user`);
-    console.info(`   Output directory: ${this.saveDir}`);
-    console.info(`   Summary: ${summaryPath}`);
   }
 }
 


### PR DESCRIPTION
Adds `--save-reports-json` and `--save-reports-percentage` flags to save generated reports as JSON files organized by user, for workflow testing.

Closes #32
Related to [medic/cht-core#10303](https://github.com/medic/cht-core/pull/10303)
Comment https://github.com/medic/cht-core/pull/10303#discussion_r2436465442